### PR TITLE
feat:JG-23 envoie email erreur sentry

### DIFF
--- a/logs/test-error-logs
+++ b/logs/test-error-logs
@@ -1,3 +1,11 @@
+31-08-2022 10:35:37 | Europe/Paris time:-----------------------------
+this is my error message 77882439 
+31-08-2022 10:34:54 | Europe/Paris time:-----------------------------
+this is my error message 491518895 
+31-08-2022 10:27:02 | Europe/Paris time:-----------------------------
+this is my error message 857283094 
+31-08-2022 10:09:09 | Europe/Paris time:-----------------------------
+this is my error message 1705032984 
 30-08-2022 18:56:00 | Europe/Paris time:-----------------------------
 this is my error message 2137248107 
 30-08-2022 18:53:15 | Europe/Paris time:-----------------------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,7 @@
          stopOnFailure="false">
     <testsuites>
         <testsuite name="Test suite">
-            <directory>wordpress/wp-content/themes/Jegwell-front/tests</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/SentryTest.php
+++ b/tests/SentryTest.php
@@ -2,12 +2,11 @@
 
 declare(strict_types=1);
 
-$root_directory_level = 5;
-require_once dirname(__DIR__, $root_directory_level) . '/vendor/autoload.php';
-require_once dirname(__DIR__, $root_directory_level) . '/wordpress/jegwell-functions.php';
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+require_once dirname(__DIR__) . '/wordpress/jegwell-functions.php';
 
 /** @desc this instantiates Dotenv and passes in our path to .env */
-$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__, $root_directory_level));
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(__DIR__));
 $dotenv->load();
 
 use PHPUnit\Framework\TestCase;
@@ -23,7 +22,7 @@ class jegwellFuntionsTest extends TestCase
     {
         $inputs = array(123, "345", true, false, null);
         foreach ($inputs as $input) {
-            $result = initializeSentry($input);
+            $result = initializeSentry($input, "development");
             $this->assertSame($result, array("status" => "fail", "email" => "success"));
         }
     }
@@ -40,7 +39,7 @@ class jegwellFuntionsTest extends TestCase
         $randomId = rand();
         $message = "this is my error message {$randomId}";
         $type = 'test-error';
-        $logPath  = dirname(__DIR__, 5) . "/logs/{$type}-logs";
+        $logPath  = dirname(__DIR__) . "/logs/{$type}-logs";
         $previousContent = file_exists($logPath) ? file_get_contents($logPath) : "default";
 
         addToLogs('test-error', $message);

--- a/wordpress/jegwell-functions.php
+++ b/wordpress/jegwell-functions.php
@@ -4,9 +4,8 @@ namespace Jegwell\functions;
 
 //Import PHPMailer classes into the global namespace
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\SMTP;
 
-function initializeSentry($dsn)
+function initializeSentry($dsn, $environment)
 {
 
   try {
@@ -15,7 +14,7 @@ function initializeSentry($dsn)
     }
 
     // Initialise Sentry.io
-    \Sentry\init(['dsn' => $dsn]);
+    \Sentry\init(['dsn' => $dsn, 'environment' => $environment,]);
 
     return array("status" => "success");
   } catch (\Throwable $th) {

--- a/wordpress/wp-config.php
+++ b/wordpress/wp-config.php
@@ -10,7 +10,7 @@ $dotenv->load();
 
 use function Jegwell\functions\initializeSentry;
 
-initializeSentry($_ENV['SENTRY_DSN']);
+initializeSentry($_ENV['SENTRY_DSN'], $_ENV['WORDPRESS_ENV']);
 
 /**
  * The base configuration for WordPress


### PR DESCRIPTION
# Identifiant ticket (ex: JG-7): JG-23

# Toutes les cases doivent être cochées avant de merger le code sur github (sauf exception justifiée avec un commentaire).

- [X] Le code est expliqué dans le commit en suivant la convention (atomique, [type]:JG-[number] [description], 1ère ligne <= 50 cacaractères et les 3 questions).
- [X] Les résultats des tests unitaires sont fournis dans la section "Résultats des tests unitaires" en-dessous
- [X] La convention d'écriture du code est respecté (nommage, indentation, etc.).
- [X] Les travaux temporaires sont supprimés (code commenté, logs inutiles, pas de numéro de ticket dans le code, pas de nom de développeur, etc).
- [X] Pas de nouveau warning ou erreur dans la console du navigateur.
- [X] Tous les tests (unitaire, intégration, etc) passent avec succès
- [/] De nouveaux tests ont été ajoutés.
- [X] La documentation a été mise à jour
- [X] Le code a été commenté lorsque nécessaire.

# Résultats des tests unitaires:

<details>
<summary>Collapse/develop results.</summary>
<pre><code>
composer tests
> ./vendor/bin/phpunit --verbose --debug
PHPUnit 9.5.23 #StandWithUkraine

Runtime:       PHP 7.4.30
Configuration: /home/benjamin/myStuff/Jegwell/code/phpunit.xml

Test 'jegwellFuntionsTest::testSentryWrongDsn' started
Test 'jegwellFuntionsTest::testSentryWrongDsn' ended
Test 'jegwellFuntionsTest::testSentryInitialization' started
Test 'jegwellFuntionsTest::testSentryInitialization' ended
Test 'jegwellFuntionsTest::testaddToLogs' started
Test 'jegwellFuntionsTest::testaddToLogs' ended


Time: 00:03.940, Memory: 8.00 MB

OK (3 tests, 8 assertions)
</code></pre>
</details>